### PR TITLE
Adjust path to local ipuzzler library (wrong directory)

### DIFF
--- a/gh-pages/show-puzzle.html
+++ b/gh-pages/show-puzzle.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>iPuzzler Demo</title>
-    <script type="module" src="js/ipuzzler-0.1.12.js"></script>
+    <script type="module" src="ipuzzler/ipuzzler-0.1.12.js"></script>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
 <body>


### PR DESCRIPTION
Hey Dylan,

today, I've tried to run a local build. After some meddling here and there, I believe the path to the JS file is wrong.

I'm about to open another PR to add local-development instructions to the README.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>