### PR TITLE
Support for no solution and submitting answers

### DIFF
--- a/src/ipuzzler.js
+++ b/src/ipuzzler.js
@@ -10,12 +10,12 @@ export class IPuzzler extends HTMLElement {
         window.addEventListener("resize", this.resize.bind(this));
     }
 
-    load(url) {
-        fetch(url).then(response => response.json()).then(json => this.init(json, url));
+    load(url, submitUrl) {
+        fetch(url).then(response => response.json()).then(json => this.init(json, url, submitUrl));
     }
 
-    init(json, url) {
-        this.puzzle = Parser.parse(json, url);
+    init(json, url, submitUrl) {
+        this.puzzle = Parser.parse(json, url, submitUrl);
         this.renderer = new Renderer(this.shadow);
         this.renderer.render(this.puzzle);
         this.renderer.inputs.forEach(input => {
@@ -29,11 +29,13 @@ export class IPuzzler extends HTMLElement {
 
     connectedCallback() {
         let url = this.getAttribute("src");
-        if (url) this.load(url);
+        let submitUrl = this.getAttribute("submitUrl");
+        if (url) this.load(url, submitUrl);
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
         switch (name) {
+            // how do we get the submitUrl?
             case 'url': this.load(newValue); break;
         }
     }
@@ -73,6 +75,7 @@ export class IPuzzler extends HTMLElement {
             case 'check-grid-button': this.puzzle.checkGrid(); break;
             case 'clear-grid-button': this.puzzle.clearGrid(); break;
             case 'cheat-grid-button': if (confirm('Are you sure you want to reveal all solutions?')) this.puzzle.cheatGrid(); break;
+            case 'submit-button': this.puzzle.submitGrid(button.closest("form")); break;
         }
         this.renderer.update(this.puzzle);
     }

--- a/src/ipuzzler.scss
+++ b/src/ipuzzler.scss
@@ -21,7 +21,7 @@ div.ipuzzler {
     div#buttons {
         text-align: center;
         button {
-            margin: 4px 4px 2px 0px;
+            margin: 6px 4px 2px 0px;
             width: 6em;
             background-color: #36f;
             border: 0;
@@ -32,7 +32,23 @@ div.ipuzzler {
         }
         div#grid-buttons {
             button {
-                background-color: #9cf;
+                background-color: lighten(#36f,15%);
+            }
+        }
+        div#grid-buttons.no-solution {
+            display: inline;
+        }
+        div#clue-buttons.no-solution {
+            display: inline;
+            button {
+                background-color: lighten(#36f,15%);
+            }
+        }
+        div#submit-buttons {
+            button {
+                background-color: #36f;
+                padding: 6px;
+                width: 10em;
             }
         }
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,11 +3,11 @@ import { Clue } from "./clue";
 import { Cell } from "./cell";
 
 export class Parser {
-    static parse(ipuzData, uri) {
+    static parse(ipuzData, uri, submitUrl) {
 
         let cells = ipuzData.puzzle.map((ipuzCells, row) => ipuzCells.map((ipuzCell, col) => new Cell(ipuzCell, row, col)));
 
-        Parser.attachSolutions(cells, ipuzData.solution);
+        let hasSolution = Parser.attachSolutions(cells, ipuzData.solution);
 
         let clueKeys = Object.keys(ipuzData.clues);
         
@@ -35,17 +35,18 @@ export class Parser {
         clues.across.heading = (acrossKey.split(":")[1] ?? "Across");
         clues.down.heading = (downKey.split(":")[1] ?? "Down");
 
-        return new Puzzle(cells, clues, uri);
+        return new Puzzle(cells, clues, uri, hasSolution, submitUrl);
     }
 
     static attachSolutions(cells, solution) {
-        if (! solution) return;
+        if (! solution) return false;
         cells.forEach((line, row) => line.forEach((cell, col) => {
             if (solution[row] && solution[row][col]) {
                 let value = (solution[row][col].value || solution[row][col]);
                 if (value.toUpperCase && /[A-Z]/i.test(value)) cell.solution = value.toUpperCase();
             }
         }));
+        return true;
     }
 
     static findCellForClue(cells, clue) {

--- a/src/puzzle.js
+++ b/src/puzzle.js
@@ -1,5 +1,5 @@
 export class Puzzle {
-    constructor(cells, clues, uri) {
+    constructor(cells, clues, uri, hasSolution, submitUrl) {
         this.uri = uri || "";
         this.cells = cells;
         this.allCells.forEach(cell => cell.puzzle = this);
@@ -8,6 +8,8 @@ export class Puzzle {
         this.direction = 'across';
         this.acrossHeading = "Across";
         this.downHeading = "Down";
+        this.hasSolution = hasSolution;
+        this.submitUrl = submitUrl;
     }
 
     isClueBirectional(number) {
@@ -129,8 +131,23 @@ export class Puzzle {
 
     checkClue() { if (this.focusedClue) this.focusedClue.check(); }
     clearClue() { if (this.focusedClue) this.focusedClue.clear(); }
-    cheatClue() { if (this.focusedClue) this.focusedClue.cheat();}
+    cheatClue() { if (this.focusedClue) this.focusedClue.cheat(); }
     checkGrid() { this.allCells.forEach(cell => cell.check()); }
     clearGrid() { this.allCells.forEach(cell => cell.clear()); }
-    cheatGrid() { this.allCells.forEach(cell => cell.cheat());}
+    cheatGrid() { this.allCells.forEach(cell => cell.cheat()); }
+
+    submitGrid(form) {
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var cookie = decodedCookie.split(/; */).map(token => token.split('=')).find(pair => pair[0] == this.cookieName);
+        if (cookie && cookie.length > 1) {
+            // validate that entered all boxes
+            if (this.allCells.some(e => e.style === "" && e.value === "")) {
+                alert("You are missing some answers");
+            }
+            else {
+                form.elements["answers"].value = cookie[1];
+                form.submit();
+            }
+        }
+    }
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -120,33 +120,62 @@ export class Renderer {
         if (clue.enumeration) container.appendChild(this.createClueEnumerationSpan(clue));
     }
 
-    drawButtons() {
+    drawButtons(hasSolution, submitUrl) {
         const checkClueButton = this.html('button', { 'id': 'check-clue-button' }, "Check clue");
         const clearClueButton = this.html('button', { 'id': 'clear-clue-button' }, "Clear clue");
         const cheatClueButton = this.html('button', { 'id': 'cheat-clue-button' }, "Cheat clue");
-        const clueButtonContainer = this.html('div', { 'id': 'clue-buttons' });
-        clueButtonContainer.appendChild(checkClueButton);
-        clueButtonContainer.appendChild(clearClueButton);
-        clueButtonContainer.appendChild(cheatClueButton);
+        const clueButtonContainer = hasSolution ? 
+            this.html('div', { 'id': 'clue-buttons' }) : 
+            this.html('div', { 'id': 'clue-buttons', 'class': 'no-solution' });
 
         const checkGridButton = this.html('button', { 'id': 'check-grid-button' }, "Check grid");
         const clearGridButton = this.html('button', { 'id': 'clear-grid-button' }, "Clear grid");
         const cheatGridButton = this.html('button', { 'id': 'cheat-grid-button' }, "Cheat grid");
-        const gridButtonContainer = this.html('div', { 'id': 'grid-buttons' });
-        gridButtonContainer.appendChild(checkGridButton);
-        gridButtonContainer.appendChild(clearGridButton);
-        gridButtonContainer.appendChild(cheatGridButton);
+        const gridButtonContainer = hasSolution ? 
+            this.html('div', { 'id': 'grid-buttons' }) :
+            this.html('div', { 'id': 'grid-buttons', 'class': 'no-solution' });
+        ;
 
-        this.buttons.push(checkClueButton);
-        this.buttons.push(clearClueButton);
-        this.buttons.push(cheatClueButton);
-        this.buttons.push(checkGridButton);
-        this.buttons.push(clearGridButton);
-        this.buttons.push(cheatGridButton);
+        if (hasSolution) {
+            clueButtonContainer.appendChild(checkClueButton);
+            clueButtonContainer.appendChild(clearClueButton);
+            clueButtonContainer.appendChild(cheatClueButton);
+   
+            gridButtonContainer.appendChild(checkGridButton);
+            gridButtonContainer.appendChild(clearGridButton);
+            gridButtonContainer.appendChild(cheatGridButton);
+
+            this.buttons.push(checkClueButton);
+            this.buttons.push(clearClueButton);
+            this.buttons.push(cheatClueButton);
+            this.buttons.push(checkGridButton);
+            this.buttons.push(clearGridButton);
+            this.buttons.push(cheatGridButton);   
+        } else {
+            clueButtonContainer.appendChild(clearClueButton);
+            gridButtonContainer.appendChild(clearGridButton);
+
+            this.buttons.push(clearClueButton);
+            this.buttons.push(clearGridButton);
+        }
 
         const buttonBar = this.html('div', { 'id': 'buttons' });
         buttonBar.appendChild(clueButtonContainer);
         buttonBar.appendChild(gridButtonContainer);
+
+        if (submitUrl !== null) {
+            console.log("submitUrl: " + submitUrl);
+            const submitButton = this.html('button', { 'id': 'submit-button', 'type': 'button' }, "Submit Answers");
+            const submitButtonContainer = this.html('div', { 'id': 'submit-buttons' });
+            const submitFormContainer = this.html('form', { 'method': 'POST', 'action': submitUrl });
+            const submitFormFieldContainer = this.html('input', { 'type': 'hidden', 'id': 'answers', 'name': 'answers' });
+            submitButtonContainer.appendChild(submitButton);
+            submitFormContainer.appendChild(submitButtonContainer);
+            submitFormContainer.appendChild(submitFormFieldContainer);
+            this.buttons.push(submitButton);
+            buttonBar.appendChild(submitFormContainer);
+        }
+
         return buttonBar;
     }
 
@@ -178,7 +207,7 @@ export class Renderer {
         puzzleGridWrapper.appendChild(this.aboveClueBar);
         puzzleGridWrapper.appendChild(this.grid);
         puzzleGridWrapper.appendChild(this.belowClueBar);
-        puzzleGridWrapper.appendChild(this.drawButtons());
+        puzzleGridWrapper.appendChild(this.drawButtons(puzzle.hasSolution, puzzle.submitUrl));
 
         div.appendChild(puzzleGridWrapper);
 


### PR DESCRIPTION
If the .ipuz puzzle has no solution specified, the 'cheat' and 'check' buttons do nothing. This pull request will not display those buttons if there is no solution in the puzzle json.

It also adds support for a 'Submit Answers' button that will post form data to a url. The form has a hidden `answers` field that on submit is set to the current user's answers as a single string (using the value in the cookie).

The Submit Answers button is shown if the `submitUrl` attribute is set in the ipuzzler-puzzle element, e.g.

```
<ipuzzler-puzzle src="puzzle.ipuz" submitUrl="{url to post answers}">
</ipuzzler-puzzle>
```

Am setting this as a draft pull request as - _if you wanted this functionality_ - it would need tests and examples adding. 